### PR TITLE
docs: Update picamera-zero links to picamzero

### DIFF
--- a/en/step_1.md
+++ b/en/step_1.md
@@ -1,6 +1,6 @@
 ## Introduction
 
-To use this guide, you will need to [install](https://raspberrypifoundation.github.io/picamera-zero) `picamzero` - a library designed to make using the camera on the Raspberry Pi as easy as possible.
+To use this guide, you will need to [install](https://raspberrypifoundation.github.io/picamzero) `picamzero` - a library designed to make using the camera on the Raspberry Pi as easy as possible.
 
 Learn how to connect the Raspberry Pi Camera Module to your Raspberry Pi and take pictures, record video, and apply image effects.
 

--- a/en/step_8.md
+++ b/en/step_8.md
@@ -108,7 +108,7 @@ cam.take_photo(f"{home_dir}/Desktop/textOnPhoto.jpg")
 cam.stop_preview()
 --- /code ---
 
-The `annotate` method allows you to change where the text is positioned using the `position` argument. You can also [change the text colour, font, and background colour](https://raspberrypifoundation.github.io/picamera-zero/photo_methods/annotate). 
+The `annotate` method allows you to change where the text is positioned using the `position` argument. You can also [change the text colour, font, and background colour](https://raspberrypifoundation.github.io/picamzero/photo_methods/annotate).
 
 ### Add a timestamp
 

--- a/en/step_9.md
+++ b/en/step_9.md
@@ -11,5 +11,5 @@ Try these Camera Module projects to learn more:
 - Build a [parent detector](https://projects.raspberrypi.org/en/projects/parent-detector/)
 - Use the NoIR Camera Module to create an [infrared bird box](https://projects.raspberrypi.org/en/projects/infrared-bird-box/)
 
-For more information on how to use the `picamzero` library, check out `picamzero`'s [official documentation](https://raspberrypifoundation.github.io/picamera-zero). 
+For more information on how to use the `picamzero` library, check out `picamzero`'s [official documentation](https://raspberrypifoundation.github.io/picamzero).
 


### PR DESCRIPTION
`picamzero` url has changed from `picamera-zero` to `picamzero` 